### PR TITLE
Change the order of help message arguments

### DIFF
--- a/bin/smoke
+++ b/bin/smoke
@@ -173,7 +173,7 @@ def parse_options
   immediate_exit_code = 0
 
   parser = OptionParser.new { |opts|
-    opts.banner = 'Usage: smoke [options] TEST-DIRECTORY COMMAND'
+    opts.banner = 'Usage: smoke [options] COMMAND TEST-DIRECTORY'
 
     opts.on '-c', '--[no-]color', 'Color output' do |color|
       options[:color] = color

--- a/test/help.out
+++ b/test/help.out
@@ -1,3 +1,3 @@
-Usage: smoke [options] TEST-DIRECTORY COMMAND
+Usage: smoke [options] COMMAND TEST-DIRECTORY
     -c, --[no-]color                 Color output
     -h, --help                       Help me

--- a/test/nothing.out
+++ b/test/nothing.out
@@ -1,3 +1,3 @@
-Usage: smoke [options] TEST-DIRECTORY COMMAND
+Usage: smoke [options] COMMAND TEST-DIRECTORY
     -c, --[no-]color                 Color output
     -h, --help                       Help me


### PR DESCRIPTION
The order was reversed as to how it is called in the documentation and
actual calls. Now the help message is displayed correctly.