### PR TITLE
Add nix support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .stack-work
 out
+result

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ build-dependencies: ~/.local/bin/hlint
 .PHONY: editor-dependencies
 editor-dependencies: ~/.local/bin/ghc-mod ~/.local/bin/hindent
 
+default.nix: smoke.cabal
+	cabal2nix --shell . > default.nix
+
 ~/.local/bin/ghc-mod:
 	$(STACK) install ghc-mod
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ Currently, Smoke is in alpha, and as such is not packaged. You will need to buil
 4. Run `stack install --local-bin-path=out/build` to build the application.
 5. Copy the application binary at `out/build/smoke-exe` to wherever you need it to go.
 
+If you are using [Nix][] you can build Smoke via `nix-build`.
+
 Smoke is distributed under [the MIT license][MIT License].
 
 [Stack]: https://docs.haskellstack.org/en/stable/README/
+[Nix]: https://nixos.org/nix
 [MIT License]: http://samirtalwar.mit-license.org/
 
 ## Writing Test Cases

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,37 @@
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "default", doBenchmark ? false }:
+
+let
+
+  inherit (nixpkgs) pkgs;
+
+  f = { mkDerivation, ansi-terminal, base, directory, filepath
+      , Glob, optparse-applicative, process, stdenv, transformers, unix
+      }:
+      mkDerivation {
+        pname = "smoke";
+        version = "2.0.0";
+        src = ./.;
+        isLibrary = true;
+        isExecutable = true;
+        libraryHaskellDepends = [
+          base directory filepath Glob process transformers
+        ];
+        executableHaskellDepends = [
+          ansi-terminal base optparse-applicative transformers unix
+        ];
+        homepage = "https://github.com/SamirTalwar/smoke#readme";
+        description = "An integration test framework for console applications";
+        license = stdenv.lib.licenses.mit;
+      };
+
+  haskellPackages = if compiler == "default"
+                       then pkgs.haskellPackages
+                       else pkgs.haskell.packages.${compiler};
+
+  variant = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
+
+  drv = variant (haskellPackages.callPackage f {});
+
+in
+
+  if pkgs.lib.inNixShell then drv.env else drv


### PR DESCRIPTION
Adds a default.nix for building via `nix-build`. You can also get a shell where all deps are available via `nix-shell`. I only added a brief note to the README because anyone who actually has `nix` installed and wants to build it that way prolly knows what they are doing anyway.