### PR TITLE
Update to Stackage LTS 14.9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
     fi
 
 install:
-  - stack --no-terminal install --only-dependencies
+  - stack --no-terminal install --only-dependencies --test --no-run-tests
 
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ $(OUT)/smoke-$(OS): $(BIN_RELEASE)
 	cp $(BIN_RELEASE) $(OUT)/smoke-$(OS)
 
 $(BIN_RELEASE): clean
-	stack build 
+	stack build
 	stack install --local-bin-path=$(OUT_RELEASE)
 
 $(BIN_DEBUG): $(CONF) $(SRC)
@@ -92,4 +92,4 @@ reformat: dependencies
 
 .PHONY: dependencies
 dependencies:
-	stack install --only-dependencies
+	stack install --only-dependencies --test --no-run-tests

--- a/app/Test/Smoke/App/Print.hs
+++ b/app/Test/Smoke/App/Print.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 
 module Test.Smoke.App.Print where
 

--- a/app/Test/Smoke/App/PrintErrors.hs
+++ b/app/Test/Smoke/App/PrintErrors.hs
@@ -56,17 +56,18 @@ printTestError (ExecutionError (ExecutionFilterError filterError)) =
   printFilterError filterError
 printTestError (BlessError (CouldNotBlessInlineFixture (FixtureName fixtureName') propertyValue)) =
   printError $
-  "The fixture " <> quoteString fixtureName' <>
+  "The fixture " <>
+  quoteString fixtureName' <>
   " is embedded in the test specification, so the result cannot be blessed.\nAttempted to write:\n" <>
   indentedAll messageIndentation propertyValue
 printTestError (BlessError (CouldNotBlessAMissingValue (FixtureName fixtureName'))) =
   printError $
-  "There are no expected " <> quoteString fixtureName' <>
-  " values, so the result cannot be blessed.\n"
+  "There are no expected " <>
+  quoteString fixtureName' <> " values, so the result cannot be blessed.\n"
 printTestError (BlessError (CouldNotBlessWithMultipleValues (FixtureName fixtureName'))) =
   printError $
-  "There are multiple expected " <> quoteString fixtureName' <>
-  " values, so the result cannot be blessed.\n"
+  "There are multiple expected " <>
+  quoteString fixtureName' <> " values, so the result cannot be blessed.\n"
 printTestError (BlessError (BlessIOException exception)) =
   printErrorWithException exception "Blessing failed."
 
@@ -77,18 +78,18 @@ printDiscoveryError printErrorMessage = printErrorMessage . printDiscoveryError'
     printDiscoveryError' (NoSuchLocation path) =
       "There is no such location " <> quoteString path <> "."
     printDiscoveryError' (NoSuchTest path (TestName selectedTestName)) =
-      "There is no such test " <> quoteString selectedTestName <> " in " <>
-      showPath path <>
-      "."
+      "There is no such test " <>
+      quoteString selectedTestName <> " in " <> showPath path <> "."
     printDiscoveryError' (CannotSelectTestInDirectory path (TestName selectedTestName)) =
-      "The test " <> quoteString selectedTestName <>
+      "The test " <>
+      quoteString selectedTestName <>
       " cannot be selected from the directory " <>
       showPath path <>
-      ".\n" <>
-      "Tests must be selected from a single specification file."
+      ".\n" <> "Tests must be selected from a single specification file."
     printDiscoveryError' (InvalidSpecification path message) =
-      "The test specification " <> showPath path <> " is invalid:\n" <>
-      indentedAll messageIndentation (fromString message)
+      "The test specification " <>
+      showPath path <>
+      " is invalid:\n" <> indentedAll messageIndentation (fromString message)
 
 printFilterError :: SmokeFilterError -> Output ()
 printFilterError MissingFilterScript =
@@ -98,13 +99,13 @@ printFilterError (CouldNotExecuteFilter executable exception) =
   showExecutable executable <> " could not be executed."
 printFilterError (ExecutionFailed executable (Status status) (StdOut stdOut) (StdErr stdErr)) =
   printError $
-  showExecutable executable <> " failed with an exit status of " <>
+  showExecutable executable <>
+  " failed with an exit status of " <>
   showInt status <>
   "." <>
   "\nSTDOUT:\n" <>
   indentedAll messageIndentation stdOut <>
-  "\nSTDERR:\n" <>
-  indentedAll messageIndentation stdErr
+  "\nSTDERR:\n" <> indentedAll messageIndentation stdErr
 printFilterError (FilterPathError pathError) = printPathError pathError
 
 printPathError :: PathError -> Output ()

--- a/app/Test/Smoke/App/PrintSummary.hs
+++ b/app/Test/Smoke/App/PrintSummary.hs
@@ -20,8 +20,8 @@ printSummary summary = do
           then putGreenLn
           else putRedLn
   printSummaryLine $
-    showInt testCount <> " " <> testWord <> ", " <> showInt failureCount <> " " <>
-    failureWord
+    showInt testCount <>
+    " " <> testWord <> ", " <> showInt failureCount <> " " <> failureWord
 
 pluralize :: Int -> Text -> Text -> Text
 pluralize 1 singular _ = singular

--- a/default.nix
+++ b/default.nix
@@ -34,7 +34,7 @@ let
           temporary text transformers vector yaml
         ];
         testToolDepends = [ cabal2nix hindent hlint ];
-        preConfigure = "hpack";
+        prePatch = "hpack";
         homepage = "https://github.com/SamirTalwar/smoke#readme";
         description = "An integration test framework for console applications";
         license = stdenv.lib.licenses.mit;

--- a/spec/malformed-specs.yaml
+++ b/spec/malformed-specs.yaml
@@ -7,11 +7,11 @@ tests:
       - |
         The test specification "fixtures/malformed-specs/empty.yaml" is invalid:
           Aeson exception:
-          Error in $: expected Suite, encountered Null
+          Error in $: parsing Suite failed, expected Object, but encountered Null
       - |
         The test specification "fixtures\malformed-specs\empty.yaml" is invalid:
           Aeson exception:
-          Error in $: expected Suite, encountered Null
+          Error in $: parsing Suite failed, expected Object, but encountered Null
 
   - name: invalid-yaml
     args:
@@ -37,8 +37,8 @@ tests:
       - |
         The test specification "fixtures/malformed-specs/test-as-dict.yaml" is invalid:
           Aeson exception:
-          Error in $.tests: expected [a], encountered Object
+          Error in $.tests: parsing [] failed, expected Array, but encountered Object
       - |
         The test specification "fixtures\malformed-specs\test-as-dict.yaml" is invalid:
           Aeson exception:
-          Error in $.tests: expected [a], encountered Object
+          Error in $.tests: parsing [] failed, expected Array, but encountered Object

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.18
+resolver: lts-14.7
 packages:
   - .
 extra-deps:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.7
+resolver: lts-14.9
 packages:
   - .
 extra-deps:
@@ -9,3 +9,4 @@ nix:
   packages:
     - libiconv
     - openssl
+    - zlib

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -13,7 +13,7 @@ packages:
     hackage: hindent-5.3.1
 snapshots:
 - completed:
-    size: 498365
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/18.yaml
-    sha256: c813b03544da8a9053b722f00f3f9a0aade23443130ac7160fefa89e01f5fb17
-  original: lts-13.18
+    size: 523700
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/7.yaml
+    sha256: 8e3f3c894be74d71fa4bf085e0a8baae7e4d7622d07ea31a52736b80f8b9bb1a
+  original: lts-14.7

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -13,7 +13,7 @@ packages:
     hackage: hindent-5.3.1
 snapshots:
 - completed:
-    size: 523700
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/7.yaml
-    sha256: 8e3f3c894be74d71fa4bf085e0a8baae7e4d7622d07ea31a52736b80f8b9bb1a
-  original: lts-14.7
+    size: 524789
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/9.yaml
+    sha256: 8af5eb80734f02621d37e82cc0cde614af2ddc9c320610acb0b1b6d9ac162930
+  original: lts-14.9


### PR DESCRIPTION
Changes:

- `aeson` error messages are slightly more verbose
- `hlint` found an extra unused `LANGUAGE` pragma
- `hindent` formats slightly differently now