### PR TITLE
Upgrade GitHub actions to fix the build.

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v7
-      - uses: cachix/cachix-action@v5
+      - uses: cachix/install-nix-action@v10
+      - uses: cachix/cachix-action@v6
         with:
           name: samirtalwar
           signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
@@ -43,11 +43,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v7
-      - uses: cachix/cachix-action@v5
+      - uses: cachix/install-nix-action@v10
+      - uses: cachix/cachix-action@v6
         with:
           name: samirtalwar
-          skipNixBuild: true
       - uses: actions/cache@v2
         with:
           path: ~/.cabal/store
@@ -62,9 +61,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v7
-      - uses: cachix/cachix-action@v5
+      - uses: cachix/install-nix-action@v10
+      - uses: cachix/cachix-action@v6
         with:
           name: samirtalwar
-          skipNixBuild: true
       - run: nix-shell --pure --keep LANG --run 'make lint'

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -24,7 +24,7 @@ jobs:
       - run: nix-instantiate shell.nix | cachix push samirtalwar
         env:
           CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: ~/.cabal/store
           key: v1-${{ matrix.os }}-cabal-store-${{ hashFiles('cabal.project.freeze') }}
@@ -48,7 +48,7 @@ jobs:
         with:
           name: samirtalwar
           skipNixBuild: true
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: ~/.cabal/store
           key: v1-${{ matrix.os }}-cabal-store-${{ hashFiles('cabal.project.freeze') }}


### PR DESCRIPTION
This upgrades:

- `cache-action`, for better performance,
- `cachix/install-nix-action`, which broke when Nix started requiring installation to follow redirects, and
- `cachix/cachix-action`, because we can.
