### PR TITLE
Make pkgs in default.nix overrideable.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,9 @@
-{}:
 let
   sources = import ./nix/sources.nix;
-  pkgs = import sources.nixpkgs { };
+  nixpkgs = import sources.nixpkgs { };
+in
+{ pkgs ? nixpkgs }:
+let
   ghc = import ./nix/ghc.nix { inherit (pkgs) lib haskell; };
   drv = import ./nix/smoke.nix { inherit ghc pkgs; };
   inherit (pkgs) haskell stdenv;


### PR DESCRIPTION
This allows downstream consumers to override the nixpkgs version that
should be used to build the application. The default behavior not
changed and still defaults to the niv pinned nixpkgs version.