### PR TITLE
CI: Build PRs without pushing to Cachix.

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -2,7 +2,6 @@ name: Verify
 on:
   pull_request:
   push:
-    branches: "*"
 
 jobs:
   build-unix:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -21,7 +21,12 @@ jobs:
         with:
           name: samirtalwar
           signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
-      - run: nix-instantiate shell.nix | cachix push samirtalwar
+      - run: |
+          if [[ -n "$CACHIX_SIGNING_KEY" ]]; then
+            nix-instantiate shell.nix | cachix push samirtalwar
+          else
+            nix-instantiate shell.nix
+          fi
         env:
           CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
       - uses: actions/cache@v2


### PR DESCRIPTION
Obviously, third-party PRs won't have access to the secrets, which means this won't work.