### PR TITLE
Fix the macOS build on CI, and update dependencies on the way.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,11 +44,11 @@ jobs:
       - run: nix-instantiate shell.nix | cachix push samirtalwar
         env:
           CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
-          path: ~/.cabal/store
-          key: v1-${{ matrix.os }}-cabal-store-${{ hashFiles('cabal.project.freeze') }}
-          restore-keys: v1-${{ matrix.os }}-cabal-store-
+          path: ~/.stack
+          key: v1-${{ matrix.os }}-stack-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
+          restore-keys: v1-${{ matrix.os }}-stack-
       - uses: actions/download-artifact@v1
         with:
           name: release_upload_url

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -5,4 +5,6 @@ let
 in
 pkgs.mkShell {
   buildInputs = deps ++ [ pkgs.nix ];
+
+  CI = "true";
 }

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -7,4 +7,5 @@ pkgs.mkShell {
   buildInputs = deps ++ [ pkgs.nix ];
 
   CI = "true";
+  NIX_PATH = "nixpkgs=" + sources.nixpkgs;
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "febd3530f0c2f2fb74752ee4d9dd2518d302f618",
-        "sha256": "1gifi50k4h6wk9ix0yvp66p7jk8rrqgr39r5rf4lyha6pbs7dbk6",
+        "rev": "303f442c43f918bc43400ab4a0b662a82ca7748b",
+        "sha256": "19z1qypd6zd4qzhrhjm7j55v85fzf8wln8l9vslvn9dpspcwxv7c",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/febd3530f0c2f2fb74752ee4d9dd2518d302f618.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/303f442c43f918bc43400ab4a0b662a82ca7748b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -17,10 +17,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs-channels",
-        "rev": "d7e20ee25ed8aa1f0f24a9ca77026c6ef217f6ba",
-        "sha256": "1ar7prnrmmlqj17g57nqp82hgy5283dxb94akaqrwpbaz7qfwi4y",
+        "rev": "d418434d127bd2423b9115768d9cbf80ed5da52a",
+        "sha256": "0vxijr0n3d4c6r5mh0ph6ip7m56ih7kgc3bwmv1w12hbjmc6i5fr",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/d7e20ee25ed8aa1f0f24a9ca77026c6ef217f6ba.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs-channels/archive/d418434d127bd2423b9115768d9cbf80ed5da52a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -5,4 +5,6 @@ let
 in
 pkgs.mkShell {
   buildInputs = deps;
+
+  NIX_PATH = "nixpkgs=" + sources.nixpkgs;
 }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.5
+resolver: lts-16.8
 packages:
   - .
 ghc-options:


### PR DESCRIPTION
Stack was using the wrong version of nixpkgs.

While I was here, I fixed the cache restoration in _.github/workflows/release.yaml_ so that it caches Stack artifacts, not Cabal.