### PR TITLE
Fix the release process.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
           CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
       # - uses: actions/cache@v2
       #   with:
-      #     path: ~/.stack
+      #     path: ~/.stack/snapshots
       #     key: v1-${{ matrix.os }}-stack-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
       - run: |
           mkdir -p ~/.stack

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,14 @@ jobs:
       #   with:
       #     path: ~/.stack
       #     key: v1-${{ matrix.os }}-stack-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
+      - run: |
+          mkdir -p ~/.stack
+          cat > ~/.stack/config.yaml <<EOF
+          nix:
+            enable: true
+          EOF
+      - run: nix-shell --pure --keep LANG ./nix/ci.nix --run 'make smoke.cabal'
+      - run: nix-shell --pure --keep LANG ./nix/ci.nix --run 'make out/build/release/smoke'
       - uses: actions/download-artifact@v1
         with:
           name: release_upload_url
@@ -60,8 +68,6 @@ jobs:
           export ASSET_NAME="smoke-${TAG##*/}-$(uname -s)-$(uname -m)"
           echo ::set-output name=asset_name::"$ASSET_NAME"
           echo ::set-output name=asset_path::"out/publish/${ASSET_NAME}"
-      - run: nix-shell --pure --keep LANG ./nix/ci.nix --run 'make smoke.cabal'
-      - run: nix-shell --pure --keep LANG ./nix/ci.nix --run 'make out/build/release/smoke'
       - run: |
           mkdir -p "$(dirname ${{ steps.asset.outputs.asset_path }})"
           cp out/build/release/smoke ${{ steps.asset.outputs.asset_path }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,8 +36,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v7
-      - uses: cachix/cachix-action@v5
+      - uses: cachix/install-nix-action@v10
+      - uses: cachix/cachix-action@v6
         with:
           name: samirtalwar
           signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,12 +47,8 @@ jobs:
       - id: asset
         run: |
           export TAG="${{ github.ref }}"
-          export ASSET_NAME="smoke-${TAG##*/}-$(uname -s)-$(uname -m)"
-          echo ::set-output name=asset_name::"$ASSET_NAME"
-          echo ::set-output name=asset_path::"out/publish/${ASSET_NAME}"
-      - run: |
-          mkdir -p "$(dirname ${{ steps.asset.outputs.asset_path }})"
-          cp out/build/release/smoke ${{ steps.asset.outputs.asset_path }}
+          echo "::set-output name=asset_name::smoke-${TAG##*/}-$(uname -s)-$(uname -m)"
+          echo "::set-output name=asset_path::out/build/release/smoke"
       - uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - id: create_release
-        uses: actions/create-release@latest
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -19,7 +19,7 @@ jobs:
           body: ${{ github.ref }}
           draft: true
       - run: echo "${{ steps.create_release.outputs.upload_url }}" > release_upload_url.txt
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v2
         with:
           name: release_upload_url
           path: release_upload_url.txt
@@ -47,7 +47,7 @@ jobs:
           key: v1-${{ matrix.os }}-stack-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
       - run: make smoke.cabal
       - run: make out/build/release/smoke
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v2
         with:
           name: release_upload_url
       - id: release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - id: create_release
         uses: actions/create-release@latest
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-20.04
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-20.04
+    outputs:
+      release_upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - id: create_release
         uses: actions/create-release@v1
@@ -18,11 +20,6 @@ jobs:
           release_name: ${{ github.ref }}
           body: ${{ github.ref }}
           draft: true
-      - run: echo "${{ steps.create_release.outputs.upload_url }}" > release_upload_url.txt
-      - uses: actions/upload-artifact@v2
-        with:
-          name: release_upload_url
-          path: release_upload_url.txt
 
   publish-unix:
     name: Release
@@ -47,12 +44,6 @@ jobs:
           key: v1-${{ matrix.os }}-stack-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
       - run: make smoke.cabal
       - run: make out/build/release/smoke
-      - uses: actions/download-artifact@v2
-        with:
-          name: release_upload_url
-      - id: release
-        run: |
-          echo ::set-output name=upload_url::"$(cat release_upload_url/release_upload_url.txt)"
       - id: asset
         run: |
           export TAG="${{ github.ref }}"
@@ -66,7 +57,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
+          upload_url: ${{ needs.release.outputs.release_upload_url }}
           asset_name: ${{ steps.asset.outputs.asset_name }}
           asset_path: ${{ steps.asset.outputs.asset_path }}
           asset_content_type: application/octet-stream

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,26 +36,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v10
-      - uses: cachix/cachix-action@v6
+      - uses: actions/setup-haskell@v1
         with:
-          name: samirtalwar
-          signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
-      - run: nix-instantiate shell.nix | cachix push samirtalwar
-        env:
-          CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
-      # - uses: actions/cache@v2
-      #   with:
-      #     path: ~/.stack/snapshots
-      #     key: v1-${{ matrix.os }}-stack-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
-      - run: |
-          mkdir -p ~/.stack
-          cat > ~/.stack/config.yaml <<EOF
-          nix:
-            enable: true
-          EOF
-      - run: nix-shell --pure --keep LANG ./nix/ci.nix --run 'make smoke.cabal'
-      - run: nix-shell --pure --keep LANG ./nix/ci.nix --run 'make out/build/release/smoke'
+          ghc-version: "8.8.3"
+          enable-stack: true
+          stack-no-global: true
+      - uses: actions/cache@v2
+        with:
+          path: ~/.stack/snapshots
+          key: v1-${{ matrix.os }}-stack-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
+      - run: make smoke.cabal
+      - run: make out/build/release/smoke
       - uses: actions/download-artifact@v1
         with:
           name: release_upload_url

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -20,10 +20,10 @@ jobs:
           ghc-version: "8.8.3"
           enable-stack: true
           stack-no-global: true
-      # - uses: actions/cache@v2
-      #   with:
-      #     path: ~/.stack
-      #     key: v1-${{ matrix.os }}-stack-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
+      - uses: actions/cache@v2
+        with:
+          path: ~/.stack
+          key: v1-${{ matrix.os }}-stack-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
       - run: make smoke.cabal
       - run: make build
 
@@ -44,10 +44,10 @@ jobs:
           ghc-version: "8.8.3"
           enable-stack: true
           stack-no-global: true
-      # - uses: actions/cache@v2
-      #   with:
-      #     path: ~/.stack
-      #     key: v1-${{ matrix.os }}-stack-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
+      - uses: actions/cache@v2
+        with:
+          path: ~/.stack
+          key: v1-${{ matrix.os }}-stack-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
       - run: make smoke.cabal
       - run: make test
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -22,7 +22,7 @@ jobs:
           stack-no-global: true
       - uses: actions/cache@v2
         with:
-          path: ~/.stack
+          path: ~/.stack/snapshots
           key: v1-${{ matrix.os }}-stack-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
       - run: make smoke.cabal
       - run: make build
@@ -46,7 +46,7 @@ jobs:
           stack-no-global: true
       - uses: actions/cache@v2
         with:
-          path: ~/.stack
+          path: ~/.stack/snapshots
           key: v1-${{ matrix.os }}-stack-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
       - run: make smoke.cabal
       - run: make test

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -15,31 +15,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v10
-      - uses: cachix/cachix-action@v6
+      - uses: actions/setup-haskell@v1
         with:
-          name: samirtalwar
-          signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
-      - run: |
-          if [[ -n "$CACHIX_SIGNING_KEY" ]]; then
-            nix-instantiate shell.nix | cachix push samirtalwar
-          else
-            nix-instantiate shell.nix
-          fi
-        env:
-          CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
+          ghc-version: "8.8.3"
+          enable-stack: true
+          stack-no-global: true
       # - uses: actions/cache@v2
       #   with:
       #     path: ~/.stack
       #     key: v1-${{ matrix.os }}-stack-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
-      - run: |
-          mkdir -p ~/.stack
-          cat > ~/.stack/config.yaml <<EOF
-          nix:
-            enable: true
-          EOF
-      - run: nix-shell --pure --keep LANG ./nix/ci.nix --run 'make smoke.cabal'
-      - run: nix-shell --pure --keep LANG ./nix/ci.nix --run 'make build'
+      - run: make smoke.cabal
+      - run: make build
 
   test-unix:
     name: Build and Test
@@ -53,22 +39,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v10
-      - uses: cachix/cachix-action@v6
+      - uses: actions/setup-haskell@v1
         with:
-          name: samirtalwar
+          ghc-version: "8.8.3"
+          enable-stack: true
+          stack-no-global: true
       # - uses: actions/cache@v2
       #   with:
       #     path: ~/.stack
       #     key: v1-${{ matrix.os }}-stack-${{ hashFiles('stack.yaml') }}-${{ hashFiles('package.yaml') }}
-      - run: |
-          mkdir -p ~/.stack
-          cat > ~/.stack/config.yaml <<EOF
-          nix:
-            enable: true
-          EOF
-      - run: nix-shell --pure --keep LANG ./nix/ci.nix --run 'make smoke.cabal'
-      - run: nix-shell --pure --keep LANG ./nix/ci.nix --run 'make test'
+      - run: make smoke.cabal
+      - run: make test
 
   lint:
     name: Lint

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-20.04
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-20.04
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -54,7 +54,7 @@ jobs:
   lint:
     name: Lint
     needs: build-unix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v10


### PR DESCRIPTION
We need to build without Nix, because it results in binaries that are dynamically linked to things provided by Nix. This results in binaries that can't be run on systems without Nix.

We also fix the release build, because it was broken. Ideally we would not rebuild, instead using the same binary tested in CI on every commit, but that's to be fixed later.