### PR TITLE
Continue when a file is missing.

### DIFF
--- a/fixtures/files/smoke.yaml
+++ b/fixtures/files/smoke.yaml
@@ -102,3 +102,16 @@ tests:
     revert:
       - ./single
       - ./multiple
+
+  - name: check the wrong file
+    command:
+      - cp
+    args:
+      - input.file
+      - output.file
+    files:
+      - path: wrong.file
+        contents:
+          file: input.file
+    revert:
+      - .

--- a/spec/bless.yaml
+++ b/spec/bless.yaml
@@ -26,6 +26,10 @@ tests:
     exit-status: 1
     stdout:
       file: io/files-bless-failure.out
+    files:
+      - path: ../fixtures/files/expected/lowercase.output.file
+        contents: |
+          HERE IS SOME TEXT.
     revert:
       - ../fixtures/files
 

--- a/spec/io/files-bless-failure.out
+++ b/spec/io/files-bless-failure.out
@@ -14,5 +14,8 @@ increment a number
   succeeded
 write to two files
   succeeded
+check the wrong file
+  The fixture "files" had an error during file processing.
+  /Users/samir/src/smoke/fixtures/files/wrong.file: openFile: does not exist (No such file or directory)
 
-7 tests, 2 failures
+8 tests, 3 failures

--- a/spec/io/files-bless-failure.out
+++ b/spec/io/files-bless-failure.out
@@ -15,7 +15,10 @@ increment a number
 write to two files
   succeeded
 check the wrong file
-  The fixture "files" had an error during file processing.
-  /Users/samir/src/smoke/fixtures/files/wrong.file: openFile: does not exist (No such file or directory)
+  args:   input.file
+          output.file
+  files:
+    wrong.file:
+          does not exist
 
 8 tests, 3 failures

--- a/spec/io/files.out
+++ b/spec/io/files.out
@@ -34,5 +34,11 @@ increment a number
   succeeded
 write to two files
   succeeded
+check the wrong file
+  args:   input.file
+          output.file
+  files:
+    wrong.file:
+          does not exist
 
-7 tests, 3 failures
+8 tests, 4 failures

--- a/src/app/Test/Smoke/App/Main.hs
+++ b/src/app/Test/Smoke/App/Main.hs
@@ -60,18 +60,16 @@ runTestPlanOutcome showSuiteNames suiteName _ (TestPlanError test planningError)
   printTitle showSuiteNames suiteName (Just (testName test))
   let testError = PlanningError planningError
   printTestError testError
-  return $ TestResult test $ TestError testError
+  return $ TestError test testError
 runTestPlanOutcome showSuiteNames suiteName location (TestPlanSuccess testPlan@TestPlan {planTest = test}) = do
   printTitle showSuiteNames suiteName (Just (testName test))
   runTestPlan location testPlan
 
 runTestPlan :: ResolvedPath Dir -> TestPlan -> Output TestResult
 runTestPlan location testPlan = do
-  let test = planTest testPlan
   AppOptions {optionsMode = mode} <- ask
   executionResult <- liftIO $ runTest location testPlan
-  testOutcome <- liftIO $ assertResult location testPlan executionResult
-  let testResult = TestResult test testOutcome
+  testResult <- liftIO $ assertResult location testPlan executionResult
   modifiedTestResult <-
     case mode of
       Check -> return testResult

--- a/src/app/Test/Smoke/App/PrintErrors.hs
+++ b/src/app/Test/Smoke/App/PrintErrors.hs
@@ -44,9 +44,6 @@ printTestError (ExecutionError (NonExistentWorkingDirectory (WorkingDirectory pa
 printTestError (ExecutionError (CouldNotExecuteCommand executable exception)) =
   printErrorWithException exception $
     showExecutable executable <> " could not be executed."
-printTestError (ExecutionError (CouldNotReadFile path exception)) =
-  printErrorWithException exception $
-    "The output file " <> showPath path <> " does not exist."
 printTestError (ExecutionError (CouldNotStoreDirectory path exception)) =
   printErrorWithException exception $
     "The directory " <> showPath path <> " could not be stored."
@@ -77,6 +74,8 @@ printTestError (BlessError (CouldNotBlessContainsAssertion (FixtureName fixtureN
       <> quoteString fixtureName'
       <> " is matching a substring, so the result cannot be blessed.\nActual value:\n"
       <> indentedAll messageIndentation propertyValue
+printTestError (BlessError (CouldNotBlessAssertionFileError (FixtureName fixtureName') (CouldNotReadFile _ exception))) =
+  printErrorWithException exception $ "The fixture " <> quoteString fixtureName' <> " had an error during file processing."
 printTestError (BlessError (BlessIOException exception)) =
   printErrorWithException exception "Blessing failed."
 

--- a/src/app/Test/Smoke/App/PrintErrors.hs
+++ b/src/app/Test/Smoke/App/PrintErrors.hs
@@ -74,8 +74,6 @@ printTestError (BlessError (CouldNotBlessContainsAssertion (FixtureName fixtureN
       <> quoteString fixtureName'
       <> " is matching a substring, so the result cannot be blessed.\nActual value:\n"
       <> indentedAll messageIndentation propertyValue
-printTestError (BlessError (CouldNotBlessAssertionFileError (FixtureName fixtureName') (CouldNotReadFile _ exception))) =
-  printErrorWithException exception $ "The fixture " <> quoteString fixtureName' <> " had an error during file processing."
 printTestError (BlessError (BlessIOException exception)) =
   printErrorWithException exception "Blessing failed."
 

--- a/src/app/Test/Smoke/App/PrintResults.hs
+++ b/src/app/Test/Smoke/App/PrintResults.hs
@@ -26,8 +26,8 @@ import Text.Printf (printf)
 data PartName = ShortName String | LongName String
 
 printResult :: TestResult -> Output ()
-printResult (TestResult _ TestSuccess) = putGreenLn "  succeeded"
-printResult (TestResult test (TestFailure testPlan statusResult stdOutResult stdErrResult fileResults)) = do
+printResult (TestSuccess _) = putGreenLn "  succeeded"
+printResult (TestFailure testPlan@TestPlan {planTest = test} statusResult stdOutResult stdErrResult fileResults) = do
   printFailingInput
     "args"
     ( Text.unlines . Vector.toList . Vector.map fromString . unArgs
@@ -38,8 +38,8 @@ printResult (TestResult test (TestFailure testPlan statusResult stdOutResult std
   printFailingOutput "stdout" stdOutResult
   printFailingOutput "stderr" stdErrResult
   printFailingFilesOutput fileResults
-printResult (TestResult _ (TestError testError)) = printTestError testError
-printResult (TestResult _ TestIgnored) = putYellowLn "  ignored"
+printResult (TestError _ testError) = printTestError testError
+printResult (TestIgnored _) = putYellowLn "  ignored"
 
 printFailingInput :: (Foldable f, FixtureType a) => String -> f a -> Output ()
 printFailingInput name value =

--- a/src/app/Test/Smoke/App/PrintResults.hs
+++ b/src/app/Test/Smoke/App/PrintResults.hs
@@ -14,6 +14,7 @@ import Data.String (fromString)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Vector as Vector
+import System.IO.Error (ioeGetErrorString)
 import Test.Smoke
 import Test.Smoke.App.Diff
 import Test.Smoke.App.OptionTypes
@@ -90,6 +91,7 @@ printFailureName (LongName name) _ = do
 failureIsInline :: AssertionFailure a -> Bool
 failureIsInline AssertionFailureDiff {} = True
 failureIsInline AssertionFailureContains {} = False
+failureIsInline AssertionFailureFileError {} = True
 
 printFailure :: AssertionFailure Text -> Output ()
 printFailure (AssertionFailureDiff expected actual) = printDiff expected actual
@@ -99,6 +101,8 @@ printFailure (AssertionFailureContains expected actual) = do
   putRedLn $ indentedAll nestedOutputIndentation expected
   putRed "    actual: "
   putRedLn $ indented nestedOutputIndentation actual
+printFailure (AssertionFailureFileError (CouldNotReadFile _ exception)) = do
+  putRedLn $ fromString (ioeGetErrorString exception)
 
 printDiff :: Text -> Text -> Output ()
 printDiff left right = do

--- a/src/app/Test/Smoke/App/PrintResults.hs
+++ b/src/app/Test/Smoke/App/PrintResults.hs
@@ -26,18 +26,20 @@ import Text.Printf (printf)
 data PartName = ShortName String | LongName String
 
 printResult :: TestResult -> Output ()
-printResult (TestSuccess _) = putGreenLn "  succeeded"
-printResult (TestFailure testPlan@TestPlan {planTest = test} statusResult stdOutResult stdErrResult fileResults) = do
-  printFailingInput
-    "args"
-    ( Text.unlines . Vector.toList . Vector.map fromString . unArgs
-        <$> testArgs test
-    )
-  printFailingInput "input" (planStdIn testPlan <$ testStdIn test)
-  printFailingOutput "status" (toAssertionResult ((<> "\n") . showInt . unStatus <$> statusResult))
-  printFailingOutput "stdout" stdOutResult
-  printFailingOutput "stderr" stdErrResult
-  printFailingFilesOutput fileResults
+printResult result@(TestResult testPlan@TestPlan {planTest = test} statusResult stdOutResult stdErrResult fileResults)
+  | isSuccess result =
+    putGreenLn "  succeeded"
+  | otherwise = do
+    printFailingInput
+      "args"
+      ( Text.unlines . Vector.toList . Vector.map fromString . unArgs
+          <$> testArgs test
+      )
+    printFailingInput "input" (planStdIn testPlan <$ testStdIn test)
+    printFailingOutput "status" (toAssertionResult ((<> "\n") . showInt . unStatus <$> statusResult))
+    printFailingOutput "stdout" stdOutResult
+    printFailingOutput "stderr" stdErrResult
+    printFailingFilesOutput fileResults
 printResult (TestError _ testError) = printTestError testError
 printResult (TestIgnored _) = putYellowLn "  ignored"
 

--- a/src/app/Test/Smoke/App/PrintResults.hs
+++ b/src/app/Test/Smoke/App/PrintResults.hs
@@ -102,7 +102,7 @@ printFailure (AssertionFailureContains expected actual) = do
   putRedLn $ indentedAll nestedOutputIndentation (serializeFixture expected)
   putRed "    actual: "
   putRedLn $ indented nestedOutputIndentation (serializeFixture actual)
-printFailure (AssertionFailureFileError (CouldNotReadFile _ exception)) = do
+printFailure (AssertionFailureFileError (SmokeFileError exception)) = do
   putRedLn $ fromString (ioeGetErrorString exception)
 
 printDiff :: Text -> Text -> Output ()

--- a/src/lib/Test/Smoke/Bless.hs
+++ b/src/lib/Test/Smoke/Bless.hs
@@ -63,8 +63,8 @@ serializeFailure (TestOutput _ (Inline _)) (SingleAssertionFailure (AssertionFai
   throwIO $ CouldNotBlessInlineFixture (fixtureName @a) (serializeFixture actual)
 serializeFailure (TestOutput _ _) (SingleAssertionFailure (AssertionFailureContains _ actual)) =
   throwIO $ CouldNotBlessContainsAssertion (fixtureName @a) (serializeFixture actual)
-serializeFailure (TestOutput _ _) (SingleAssertionFailure (AssertionFailureFileError fileError)) =
-  throwIO $ CouldNotBlessAssertionFileError (fixtureName @a) fileError
+serializeFailure (TestOutput _ _) (SingleAssertionFailure (AssertionFailureFileError _)) =
+  return Nothing
 serializeFailure _ (MultipleAssertionFailures _) =
   throwIO $ CouldNotBlessWithMultipleValues (fixtureName @a)
 

--- a/src/lib/Test/Smoke/Bless.hs
+++ b/src/lib/Test/Smoke/Bless.hs
@@ -53,6 +53,8 @@ serializeFailure (TestOutput _ (Inline _)) (SingleAssertionFailure (AssertionFai
   throwIO $ CouldNotBlessInlineFixture (fixtureName @a) (serializeFixture actual)
 serializeFailure (TestOutput _ _) (SingleAssertionFailure (AssertionFailureContains _ actual)) =
   throwIO $ CouldNotBlessContainsAssertion (fixtureName @a) (serializeFixture actual)
+serializeFailure (TestOutput _ _) (SingleAssertionFailure (AssertionFailureFileError fileError)) =
+  throwIO $ CouldNotBlessAssertionFileError (fixtureName @a) fileError
 serializeFailure _ (MultipleAssertionFailures _) =
   throwIO $ CouldNotBlessWithMultipleValues (fixtureName @a)
 

--- a/src/lib/Test/Smoke/Execution.hs
+++ b/src/lib/Test/Smoke/Execution.hs
@@ -8,7 +8,6 @@ import Control.Monad (unless)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Except (ExceptT (..), runExceptT, throwE, withExceptT)
 import qualified Data.Map.Strict as Map
-import Data.Text (Text)
 import Data.Vector (Vector)
 import qualified Data.Vector as Vector
 import System.Directory
@@ -44,15 +43,17 @@ executeTest location (TestPlan _ workingDirectory _ executable args processStdIn
     (exitCode, processStdOut, processStdErr) <-
       tryIO (CouldNotExecuteCommand executable) $
         runExecutable executable args processStdIn (Just workingDirectory)
-    actualFiles <-
-      Map.map TestFileContents . Map.fromList
-        <$> mapM readTestFile (Map.keys files)
+    actualFiles <- Map.fromList <$> mapM (liftIO . readTestFile) (Map.keys files)
     return $ ActualOutputs (convertExitCode exitCode) (StdOut processStdOut) (StdErr processStdErr) actualFiles
   where
-    readTestFile :: RelativePath File -> Execution (ResolvedPath File, Text)
+    readTestFile :: RelativePath File -> IO (ResolvedPath File, ActualFile)
     readTestFile path = do
       let absolutePath = location </> path
-      contents <- tryIO (CouldNotReadFile path) $ readFromPath absolutePath
+      contents <-
+        either
+          (ActualFileError . CouldNotReadFile path)
+          (ActualFileContents . TestFileContents)
+          <$> tryIOError (readFromPath absolutePath)
       return (absolutePath, contents)
 
 revertingDirectories :: Vector (ResolvedPath Dir) -> Execution a -> Execution a

--- a/src/lib/Test/Smoke/Execution.hs
+++ b/src/lib/Test/Smoke/Execution.hs
@@ -51,7 +51,7 @@ executeTest location (TestPlan _ workingDirectory _ executable args processStdIn
       let absolutePath = location </> path
       contents <-
         either
-          (ActualFileError . CouldNotReadFile path)
+          (ActualFileError . SmokeFileError)
           (ActualFileContents . TestFileContents)
           <$> tryIOError (readFromPath absolutePath)
       return (absolutePath, contents)

--- a/src/lib/Test/Smoke/Summary.hs
+++ b/src/lib/Test/Smoke/Summary.hs
@@ -23,7 +23,7 @@ summarizeResults results = Summary successes failures ignored
     ignored = length $ filter (== Ignored) allResults
 
 summarizeResult :: TestResult -> SummaryResult
-summarizeResult (TestResult _ TestSuccess) = Success
-summarizeResult (TestResult _ TestFailure {}) = Failure
-summarizeResult (TestResult _ TestError {}) = Failure
-summarizeResult (TestResult _ TestIgnored) = Ignored
+summarizeResult TestSuccess {} = Success
+summarizeResult TestFailure {} = Failure
+summarizeResult TestError {} = Failure
+summarizeResult TestIgnored {} = Ignored

--- a/src/lib/Test/Smoke/Summary.hs
+++ b/src/lib/Test/Smoke/Summary.hs
@@ -1,5 +1,6 @@
 module Test.Smoke.Summary
   ( summarizeResults,
+    summaryTotal,
   )
 where
 
@@ -23,7 +24,11 @@ summarizeResults results = Summary successes failures ignored
     ignored = length $ filter (== Ignored) allResults
 
 summarizeResult :: TestResult -> SummaryResult
-summarizeResult TestSuccess {} = Success
-summarizeResult TestFailure {} = Failure
+summarizeResult result@TestResult {}
+  | isSuccess result = Success
+  | otherwise = Failure
 summarizeResult TestError {} = Failure
 summarizeResult TestIgnored {} = Ignored
+
+summaryTotal :: Summary -> Int
+summaryTotal (Summary successes failures ignored) = successes + failures + ignored

--- a/src/lib/Test/Smoke/Types/Assert.hs
+++ b/src/lib/Test/Smoke/Types/Assert.hs
@@ -6,6 +6,7 @@ module Test.Smoke.Types.Assert where
 import Data.Default (Default (..))
 import Data.Vector (Vector)
 import Test.Smoke.Types.Base
+import Test.Smoke.Types.Errors
 import Test.Smoke.Types.Filters
 
 data Assert a where
@@ -19,6 +20,7 @@ instance (Default a, Eq a) => Default (Assert a) where
 data AssertionFailure a
   = AssertionFailureDiff a a
   | AssertionFailureContains a a
+  | AssertionFailureFileError SmokeFileError
   deriving (Functor)
 
 data AssertionFailures a

--- a/src/lib/Test/Smoke/Types/Errors.hs
+++ b/src/lib/Test/Smoke/Types/Errors.hs
@@ -71,8 +71,7 @@ data SmokeFilterError
 
 instance Exception SmokeFilterError
 
-data SmokeFileError
-  = CouldNotReadFile (RelativePath File) IOError
+newtype SmokeFileError = SmokeFileError IOError
   deriving (Show)
 
 instance Exception SmokeFileError

--- a/src/lib/Test/Smoke/Types/Errors.hs
+++ b/src/lib/Test/Smoke/Types/Errors.hs
@@ -40,7 +40,6 @@ instance Exception SmokePlanningError
 data SmokeExecutionError
   = NonExistentWorkingDirectory WorkingDirectory
   | CouldNotExecuteCommand Executable IOError
-  | CouldNotReadFile (RelativePath File) IOError
   | CouldNotStoreDirectory (ResolvedPath Dir) IOError
   | CouldNotRevertDirectory (ResolvedPath Dir) IOError
   deriving (Show)
@@ -58,6 +57,7 @@ data SmokeBlessError
   | CouldNotBlessAMissingValue FixtureName
   | CouldNotBlessWithMultipleValues FixtureName
   | CouldNotBlessContainsAssertion FixtureName Text
+  | CouldNotBlessAssertionFileError FixtureName SmokeFileError
   | BlessIOException IOException
   deriving (Show)
 
@@ -71,6 +71,12 @@ data SmokeFilterError
   deriving (Show)
 
 instance Exception SmokeFilterError
+
+data SmokeFileError
+  = CouldNotReadFile (RelativePath File) IOError
+  deriving (Show)
+
+instance Exception SmokeFileError
 
 data SuiteError
   = SuiteDiscoveryError SmokeDiscoveryError

--- a/src/lib/Test/Smoke/Types/Errors.hs
+++ b/src/lib/Test/Smoke/Types/Errors.hs
@@ -57,7 +57,6 @@ data SmokeBlessError
   | CouldNotBlessAMissingValue FixtureName
   | CouldNotBlessWithMultipleValues FixtureName
   | CouldNotBlessContainsAssertion FixtureName Text
-  | CouldNotBlessAssertionFileError FixtureName SmokeFileError
   | BlessIOException IOException
   deriving (Show)
 

--- a/src/lib/Test/Smoke/Types/ExecutionResult.hs
+++ b/src/lib/Test/Smoke/Types/ExecutionResult.hs
@@ -12,4 +12,6 @@ data ExecutionResult
 
 data ActualOutputs = ActualOutputs Status StdOut StdErr ActualFiles
 
-type ActualFiles = Map (ResolvedPath File) TestFileContents
+type ActualFiles = Map (ResolvedPath File) ActualFile
+
+data ActualFile = ActualFileContents TestFileContents | ActualFileError SmokeFileError

--- a/src/lib/Test/Smoke/Types/Results.hs
+++ b/src/lib/Test/Smoke/Types/Results.hs
@@ -17,18 +17,15 @@ data SuiteResult
   | SuiteResult SuiteName (ResolvedPath Dir) [TestResult]
 
 data TestResult
-  = TestResult Test TestOutcome
-
-data TestOutcome
-  = TestSuccess
+  = TestSuccess Test
   | TestFailure
       TestPlan
       (EqualityResult Status)
       (AssertionResult StdOut)
       (AssertionResult StdErr)
       (Map (RelativePath File) (AssertionResult TestFileContents))
-  | TestError SmokeError
-  | TestIgnored
+  | TestError Test SmokeError
+  | TestIgnored Test
 
 class IsSuccess a where
   isSuccess :: a -> Bool

--- a/src/lib/Test/Smoke/Types/Results.hs
+++ b/src/lib/Test/Smoke/Types/Results.hs
@@ -24,11 +24,12 @@ data SuiteResult
 
 data TestResult
   = TestResult
-      TestPlan
-      (EqualityResult Status)
-      (AssertionResult StdOut)
-      (AssertionResult StdErr)
-      (Map (RelativePath File) (AssertionResult TestFileContents))
+      { resultPlan :: TestPlan,
+        resultStatus :: EqualityResult Status,
+        resultStdOut :: AssertionResult StdOut,
+        resultStdErr :: AssertionResult StdErr,
+        resultFiles :: Map (RelativePath File) (AssertionResult TestFileContents)
+      }
   | TestError Test SmokeError
   | TestIgnored Test
 

--- a/src/lib/Test/Smoke/Types/Summary.hs
+++ b/src/lib/Test/Smoke/Types/Summary.hs
@@ -5,6 +5,3 @@ data Summary = Summary
     summaryFailures :: Int,
     summaryIgnored :: Int
   }
-
-summaryTotal :: Summary -> Int
-summaryTotal (Summary successes failures ignored) = successes + failures + ignored


### PR DESCRIPTION
If an expected output file is missing, don't crash, but print a failure and carry on.

This also enhances the bless functionality to preserve the failure rather than converting it into an error.