### PR TITLE
Make the GHC version configurable through Nix.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,9 +2,11 @@ let
   sources = import ./nix/sources.nix;
   nixpkgs = import sources.nixpkgs { };
 in
-{ pkgs ? nixpkgs }:
+{ pkgs ? nixpkgs
+, ghcVersion ? pkgs.lib.strings.fileContents ./ghc.version
+}:
 let
-  ghc = import ./nix/ghc.nix { inherit (pkgs) lib haskell; };
+  ghc = import ./nix/ghc.nix { inherit (pkgs) lib haskell; inherit ghcVersion; };
   drv = import ./nix/smoke.nix { inherit ghc pkgs; };
   inherit (pkgs) haskell stdenv;
   inherit (haskell.lib) doStrip justStaticExecutables overrideCabal;

--- a/nix/ghc.nix
+++ b/nix/ghc.nix
@@ -1,6 +1,8 @@
-{ lib, haskell }:
+{ lib
+, haskell
+, ghcVersion ? lib.strings.fileContents ../ghc.version
+}:
 let
-  version = lib.strings.fileContents ../ghc.version;
-  compiler = "ghc" + lib.strings.stringAsChars (c: if c == "." then "" else c) version;
+  compiler = "ghc" + lib.strings.stringAsChars (c: if c == "." then "" else c) ghcVersion;
 in
 haskell.packages."${compiler}"


### PR DESCRIPTION
Mostly because old versions can disappear.