### PR TITLE
Make sure the full path is included in JSON errors.

### DIFF
--- a/fixtures/malformed-specs/unknown-matcher.yaml
+++ b/fixtures/malformed-specs/unknown-matcher.yaml
@@ -1,0 +1,13 @@
+command:
+  - ruby
+  - fixtures/calculator.rb
+
+tests:
+  - name: addition
+    stdin: |
+      2 + 2
+    stdout:
+      compute:
+        plus:
+          - 2
+          - 2

--- a/fixtures/malformed-specs/wrong-type.yaml
+++ b/fixtures/malformed-specs/wrong-type.yaml
@@ -1,0 +1,9 @@
+command:
+  - ruby
+  - fixtures/calculator.rb
+
+tests:
+  - name: addition
+    stdin: |
+      2 + 2
+    stdout: [4]

--- a/package.yaml
+++ b/package.yaml
@@ -13,6 +13,10 @@ synopsis: An integration test framework for console applications.
 category: Testing
 description: Please see README.md
 
+default-extensions:
+  - DataKinds
+  - ScopedTypeVariables
+
 dependencies:
   - base >= 4.13 && < 5
   - aeson
@@ -41,8 +45,6 @@ library:
     - -Wall
     - -Werror
     - -Wno-unticked-promoted-constructors
-  default-extensions:
-    - DataKinds
   when:
     condition: os(windows)
     then:
@@ -70,8 +72,6 @@ executables:
       - -threaded
       - -rtsopts
       - -with-rtsopts=-N
-    default-extensions:
-      - DataKinds
     when:
       condition: os(windows)
       then:
@@ -94,8 +94,6 @@ tests:
       - -threaded
       - -rtsopts
       - -with-rtsopts=-N
-    default-extensions:
-      - DataKinds
     dependencies:
       - smoke
       - hedgehog

--- a/spec/malformed-specs.yaml
+++ b/spec/malformed-specs.yaml
@@ -42,3 +42,17 @@ tests:
         The test specification "fixtures\malformed-specs\test-as-dict.yaml" is invalid:
           Aeson exception:
           Error in $.tests: parsing [] failed, expected Array, but encountered Object
+
+  - name: unknown-matcher
+    args:
+      - fixtures/malformed-specs/unknown-matcher.yaml
+    exit-status: 2
+    stderr:
+      - |
+        The test specification "fixtures/malformed-specs/unknown-matcher.yaml" is invalid:
+          Aeson exception:
+          Error in $: Expected "contents" or a "file".
+      - |
+        The test specification "fixtures\malformed-specs\unknown-matcher.yaml" is invalid:
+          Aeson exception:
+          Error in $: Expected "contents" or a "file".

--- a/spec/malformed-specs.yaml
+++ b/spec/malformed-specs.yaml
@@ -6,11 +6,9 @@ tests:
     stderr:
       - |
         The test specification "fixtures/malformed-specs/empty.yaml" is invalid:
-          Aeson exception:
           Error in $: parsing Suite failed, expected Object, but encountered Null
       - |
         The test specification "fixtures\malformed-specs\empty.yaml" is invalid:
-          Aeson exception:
           Error in $: parsing Suite failed, expected Object, but encountered Null
 
   - name: invalid-yaml
@@ -36,11 +34,9 @@ tests:
     stderr:
       - |
         The test specification "fixtures/malformed-specs/test-as-dict.yaml" is invalid:
-          Aeson exception:
           Error in $.tests: parsing [] failed, expected Array, but encountered Object
       - |
         The test specification "fixtures\malformed-specs\test-as-dict.yaml" is invalid:
-          Aeson exception:
           Error in $.tests: parsing [] failed, expected Array, but encountered Object
 
   - name: unknown-matcher
@@ -50,9 +46,7 @@ tests:
     stderr:
       - |
         The test specification "fixtures/malformed-specs/unknown-matcher.yaml" is invalid:
-          Aeson exception:
           Error in $: Expected "contents" or a "file".
       - |
         The test specification "fixtures\malformed-specs\unknown-matcher.yaml" is invalid:
-          Aeson exception:
           Error in $: Expected "contents" or a "file".

--- a/spec/malformed-specs.yaml
+++ b/spec/malformed-specs.yaml
@@ -39,6 +39,18 @@ tests:
         The test specification "fixtures\malformed-specs\test-as-dict.yaml" is invalid:
           Error in $.tests: parsing [] failed, expected Array, but encountered Object
 
+  - name: wrong-type
+    args:
+      - fixtures/malformed-specs/wrong-type.yaml
+    exit-status: 2
+    stderr:
+      - |
+        The test specification "fixtures/malformed-specs/wrong-type.yaml" is invalid:
+          Error in $: expected contents, but encountered Number
+      - |
+        The test specification "fixtures\malformed-specs\wrong-type.yaml" is invalid:
+          Error in $: expected contents, but encountered Number
+
   - name: unknown-matcher
     args:
       - fixtures/malformed-specs/unknown-matcher.yaml

--- a/spec/malformed-specs.yaml
+++ b/spec/malformed-specs.yaml
@@ -46,10 +46,10 @@ tests:
     stderr:
       - |
         The test specification "fixtures/malformed-specs/wrong-type.yaml" is invalid:
-          Error in $: expected contents, but encountered Number
+          Error in $.tests[0].stdout[0]: expected contents, but encountered Number
       - |
         The test specification "fixtures\malformed-specs\wrong-type.yaml" is invalid:
-          Error in $: expected contents, but encountered Number
+          Error in $.tests[0].stdout[0]: expected contents, but encountered Number
 
   - name: unknown-matcher
     args:
@@ -58,7 +58,7 @@ tests:
     stderr:
       - |
         The test specification "fixtures/malformed-specs/unknown-matcher.yaml" is invalid:
-          Error in $: Expected "contents" or a "file".
+          Error in $.tests[0].stdout: Expected "contents" or a "file".
       - |
         The test specification "fixtures\malformed-specs\unknown-matcher.yaml" is invalid:
-          Error in $: Expected "contents" or a "file".
+          Error in $.tests[0].stdout: Expected "contents" or a "file".

--- a/spec/malformed-specs.yaml
+++ b/spec/malformed-specs.yaml
@@ -46,10 +46,10 @@ tests:
     stderr:
       - |
         The test specification "fixtures/malformed-specs/wrong-type.yaml" is invalid:
-          Error in $.tests[0].stdout[0]: expected contents, but encountered Number
+          Error in $.tests[0].stdout[0]: expected "contents" or a "file", but encountered Number
       - |
         The test specification "fixtures\malformed-specs\wrong-type.yaml" is invalid:
-          Error in $.tests[0].stdout[0]: expected contents, but encountered Number
+          Error in $.tests[0].stdout[0]: expected "contents" or a "file", but encountered Number
 
   - name: unknown-matcher
     args:
@@ -58,7 +58,7 @@ tests:
     stderr:
       - |
         The test specification "fixtures/malformed-specs/unknown-matcher.yaml" is invalid:
-          Error in $.tests[0].stdout: Expected "contents" or a "file".
+          Error in $.tests[0].stdout: Expected "contents" or a "file"
       - |
         The test specification "fixtures\malformed-specs\unknown-matcher.yaml" is invalid:
-          Error in $.tests[0].stdout: Expected "contents" or a "file".
+          Error in $.tests[0].stdout: Expected "contents" or a "file"

--- a/src/lib/Test/Smoke/Types/Values.hs
+++ b/src/lib/Test/Smoke/Types/Values.hs
@@ -22,11 +22,11 @@ instance (FixtureType a, FromJSON a) => FromJSON (Contents a) where
     maybeContents <- v .:? "contents"
     maybeFile <- v .:? "file"
     case (maybeContents, maybeFile) of
-      (Just _, Just _) -> fail "Expected \"contents\" or a \"file\", not both."
+      (Just _, Just _) -> fail "Expected \"contents\" or a \"file\", not both"
       (Just contents, Nothing) -> Inline <$> parseJSON contents
       (Nothing, Just file) -> return $ FileLocation file
-      (Nothing, Nothing) -> fail "Expected \"contents\" or a \"file\"."
-  parseJSON invalid = typeMismatch "contents" invalid
+      (Nothing, Nothing) -> fail "Expected \"contents\" or a \"file\""
+  parseJSON invalid = typeMismatch "\"contents\" or a \"file\"" invalid
 
 data TestInput a where
   TestInput :: Contents a -> TestInput a


### PR DESCRIPTION
Previously, we would have an empty path for some kinds of errors.