### PR TITLE
Preserve the executable bit when reverting files.

### DIFF
--- a/fixtures/files/hello
+++ b/fixtures/files/hello
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+echo 'Hello, world!'

--- a/fixtures/files/smoke.yaml
+++ b/fixtures/files/smoke.yaml
@@ -115,3 +115,10 @@ tests:
           file: input.file
     revert:
       - .
+
+  - name: revert an executable file
+    command: ./hello
+    stdout: |
+      Hello, world!
+    revert:
+      - .

--- a/flake.lock
+++ b/flake.lock
@@ -15,6 +15,23 @@
         "type": "github"
       }
     },
+    "haskellTar": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1657046996,
+        "narHash": "sha256-gDxF+1L0sMzwogCCTGtiYnPgZMIg5fTWV8d062F7iR0=",
+        "owner": "haskell",
+        "repo": "tar",
+        "rev": "dbf8c995153c8a80450724d9f94cf33403740c80",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "tar",
+        "rev": "dbf8c995153c8a80450724d9f94cf33403740c80",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1659739520,
@@ -34,6 +51,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "haskellTar": "haskellTar",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,15 +2,25 @@
   description = "Smoke";
 
   inputs = {
-    flake-utils.url = github:numtide/flake-utils;
+    flake-utils = {
+      url = github:numtide/flake-utils;
+    };
 
-    nixpkgs.url = github:NixOS/nixpkgs/master;
+    nixpkgs = {
+      url = github:NixOS/nixpkgs/master;
+    };
+
+    haskellTar = {
+      url = github:haskell/tar/dbf8c995153c8a80450724d9f94cf33403740c80;
+      flake = false;
+    };
   };
 
   outputs =
     { self
     , flake-utils
     , nixpkgs
+    , haskellTar
     }:
     let
       name = "smoke";
@@ -22,6 +32,9 @@
       ghc = import ./nix/ghc.nix {
         inherit (pkgs) lib haskell;
         ghcVersion = pkgs.lib.strings.fileContents ./ghc.version;
+        overrides = hself: hsuper: {
+          tar = hsuper.callCabal2nixWithOptions "tar" haskellTar "--no-check" { };
+        };
       };
       drv = import ./nix/smoke.nix { inherit ghc pkgs; };
     in

--- a/nix/ghc.nix
+++ b/nix/ghc.nix
@@ -1,8 +1,11 @@
 { lib
 , haskell
 , ghcVersion ? lib.strings.fileContents ../ghc.version
+, overrides ? _: _: { }
 }:
 let
   compiler = "ghc" + lib.strings.stringAsChars (c: if c == "." then "" else c) ghcVersion;
 in
-haskell.packages."${compiler}"
+haskell.packages."${compiler}".override {
+  inherit overrides;
+}

--- a/spec/io/files-bless-failure.out
+++ b/spec/io/files-bless-failure.out
@@ -20,5 +20,7 @@ check the wrong file
   files:
     wrong.file:
           does not exist
+revert an executable file
+  succeeded
 
-8 tests, 3 failures
+9 tests, 3 failures

--- a/spec/io/files.out
+++ b/spec/io/files.out
@@ -40,5 +40,7 @@ check the wrong file
   files:
     wrong.file:
           does not exist
+revert an executable file
+  succeeded
 
-8 tests, 4 failures
+9 tests, 4 failures

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,3 +5,6 @@ ghc-options:
   $everything: -haddock
 nix:
   shell-file: ./nix/stack.nix
+extra-deps:
+  - git: https://github.com/haskell/tar.git
+    commit: dbf8c995153c8a80450724d9f94cf33403740c80

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,7 +3,18 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    name: tar
+    pantry-tree:
+      sha256: 1a97f1a4e4e2e86e338c2629c75af9efbb64eb087efcb6adce6c19f22bfd4de0
+      size: 1985
+    commit: dbf8c995153c8a80450724d9f94cf33403740c80
+    git: https://github.com/haskell/tar.git
+    version: 0.6.0.0
+  original:
+    commit: dbf8c995153c8a80450724d9f94cf33403740c80
+    git: https://github.com/haskell/tar.git
 snapshots:
 - completed:
     sha256: 7f47507fd037228a8d23cf830f5844e1f006221acebdd7cb49f2f5fb561e0546


### PR DESCRIPTION
This was a bug in the `tar` package that is fixed in
https://github.com/haskell/tar/pull/26. However, this code has not been
released, so we need to grab the latest commit instead.