### PR TITLE
Fix non-flake setup

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,2 +1,10 @@
-let flake = builtins.getFlake (toString ./.);
-in flake.packages."${builtins.currentSystem}".default
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1667395993,
@@ -50,6 +66,7 @@
     },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "haskellTar": "haskellTar",
         "nixpkgs": "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,11 @@
       url = github:haskell/tar/dbf8c995153c8a80450724d9f94cf33403740c80;
       flake = false;
     };
+
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
   };
 
   outputs =
@@ -21,6 +26,7 @@
     , flake-utils
     , nixpkgs
     , haskellTar
+    , flake-compat
     }:
     let
       name = "smoke";

--- a/shell.nix
+++ b/shell.nix
@@ -1,2 +1,10 @@
-let flake = builtins.getFlake (toString ./.);
-in flake.devShells."${builtins.currentSystem}".default
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).shellNix


### PR DESCRIPTION
Modify default.nix and shell.nix to provide a compatibility shim using flake-compat

The `builtins.getFlake` that `default.nix` and `shell.nix` were using before is only available when the experimental `flakes` feature is actually enabled. 