### PR TITLE
Speed up linting on CI.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
           path: ${{ steps.haskell-setup.outputs.stack-root }}
           key: v1-${{ matrix.os }}-stack-${{ hashFiles('stack.yaml', 'package.yaml') }}
       - name: Install dependencies
-        run: make smoke.cabal
+        run: make deps
       - name: Build for release
         run: make out/build/release/smoke
       - id: asset

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -127,4 +127,4 @@ jobs:
         with:
           name: samirtalwar
       - name: Lint
-        run: nix develop --command make lint
+        run: nix develop .#lint --command make lint

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -32,7 +32,7 @@ jobs:
           path: ${{ steps.haskell-setup.outputs.stack-root }}
           key: v1-${{ matrix.os }}-stack-${{ hashFiles('stack.yaml', 'package.yaml') }}
       - name: Install dependencies
-        run: make smoke.cabal
+        run: make deps
       - name: Build
         run: make build
 
@@ -62,7 +62,7 @@ jobs:
           path: ${{ steps.haskell-setup.outputs.stack-root }}
           key: v1-${{ matrix.os }}-stack-${{ hashFiles('stack.yaml', 'package.yaml') }}
       - name: Install dependencies
-        run: make smoke.cabal
+        run: make deps
       - name: Test
         run: make test
 

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,10 @@ reformat: $(NIX_FILES) $(SRC)
 	ormolu --mode=inplace $(SRC)
 	nix fmt -- $(NIX_FILES)
 
+.PHONY: deps
+deps: $(CONF)
+	$(STACK) install --fast --only-dependencies --test --no-run-tests
+
 smoke.cabal: $(CONF)
 	hpack
 	touch $@

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ bless: build
 	$(BIN_DEBUG) --command=$(BIN_DEBUG) --bless spec
 
 .PHONY: lint
-lint: $(NIX_FILES) $(SRC)
+lint: $(NIX_FILES) smoke.cabal $(SRC)
 	@ echo >&2 '> hlint'
 	@ hlint $(SRC_DIR)
 	@ echo >&2 '> ormolu'
@@ -93,7 +93,7 @@ reformat: $(NIX_FILES) $(SRC)
 	nix fmt -- $(NIX_FILES)
 
 smoke.cabal: $(CONF)
-	$(STACK) install --fast --only-dependencies --test --no-run-tests
+	hpack
 	touch $@
 
 .PHONY: update-resolver

--- a/flake.nix
+++ b/flake.nix
@@ -103,5 +103,13 @@
         ];
         STACK_IN_NIX_SHELL = true;
       };
+
+      devShells.lint = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          hsPkgs.hlint
+          hsPkgs.ormolu
+        ];
+        STACK_IN_NIX_SHELL = true;
+      };
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -34,14 +34,20 @@
                     # see https://gitlab.haskell.org/ghc/ghc/-/issues/22425
                     ListLike = super.haskell.lib.dontCheck hsuper.ListLike;
 
-                    # On aarch64-darwin, this creates a cycle.
-                    # see https://github.com/NixOS/nixpkgs/issues/140774
-                    ormolu = super.haskell.lib.overrideCabal hsuper.ormolu (drv: { enableSeparateBinOutput = false; });
-
                     # Override tar with the patched version; see stack.yaml for details.
                     # The tests don't work.
                     tar = hsuper.callCabal2nixWithOptions "tar" haskellTar "--no-check" { };
-                  };
+                  } // (if super.stdenv.targetPlatform.isDarwin
+                  then
+                  # macOS-specific overrides:
+                    {
+                      # On aarch64-darwin, this creates a cycle.
+                      # see https://github.com/NixOS/nixpkgs/issues/140774
+                      ormolu = super.haskell.lib.overrideCabal hsuper.ormolu (drv: { enableSeparateBinOutput = false; });
+                    }
+                  else
+                  # We don't need to override anything on Linux:
+                    { });
                 };
               };
             };

--- a/flake.nix
+++ b/flake.nix
@@ -99,6 +99,7 @@
           # Haskell development
           hsPkgs.haskell-language-server
           hsPkgs.hlint
+          hsPkgs.hpack
           hsPkgs.hspec-discover
           hsPkgs.ormolu
           stack
@@ -113,6 +114,7 @@
       devShells.lint = pkgs.mkShell {
         buildInputs = with pkgs; [
           hsPkgs.hlint
+          hsPkgs.hpack
           hsPkgs.ormolu
         ];
         STACK_IN_NIX_SHELL = true;


### PR DESCRIPTION
1. Make a minimal Nix shell just for linting. We don't need HLS.
2. Don't override `ormolu` on Linux so we can use the nixpkgs cache.