### PR TITLE
Build with Ubuntu 24.04, which updates the minimum glibc version.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       release_upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -40,7 +40,7 @@ jobs:
         run: echo "ghc-version=$(cat ghc.version)" >> "$GITHUB_OUTPUT"
       - name: Set up Haskell
         id: haskell-setup
-        uses: haskell/actions/setup@v2
+        uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ steps.ghc-version.outputs.ghc-version }}
           enable-stack: true
@@ -99,7 +99,7 @@ jobs:
         run: echo "ghc-version=$(Get-Content ghc.version)" >> "$Env:GITHUB_OUTPUT"
       - name: Set up Haskell
         id: haskell-setup
-        uses: haskell/actions/setup@v2
+        uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ steps.ghc-version.outputs.ghc-version }}
           enable-stack: true

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -21,7 +21,7 @@ jobs:
         run: echo "ghc-version=$(cat ghc.version)" >> "$GITHUB_OUTPUT"
       - name: Set up Haskell
         id: haskell-setup
-        uses: haskell/actions/setup@v2
+        uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ steps.ghc-version.outputs.ghc-version }}
           enable-stack: true
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-24.04
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -68,7 +68,7 @@ jobs:
 
   build-test-nix:
     name: Build and Test with Nix
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out
         uses: actions/checkout@v3
@@ -82,7 +82,7 @@ jobs:
       - name: Build and Test
         run: nix build --out-link ./out/build/nix
       - name: Spec
-        run: ./out/build/nix/bin/smoke --command=./out/build/nix/bin/smoke spec
+        run: nix-shell --run './out/build/nix/bin/smoke --command=./out/build/nix/bin/smoke spec'
 
   build-windows:
     name: Build (windows-latest)
@@ -100,7 +100,7 @@ jobs:
         run: echo "ghc-version=$(Get-Content ghc.version)" >> "$Env:GITHUB_OUTPUT"
       - name: Set up Haskell
         id: haskell-setup
-        uses: haskell/actions/setup@v2
+        uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ steps.ghc-version.outputs.ghc-version }}
           enable-stack: true
@@ -142,7 +142,7 @@ jobs:
   lint:
     name: Lint
     needs: build-unix
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out
         uses: actions/checkout@v3

--- a/fixtures/calculator/smoke.yaml
+++ b/fixtures/calculator/smoke.yaml
@@ -58,9 +58,20 @@ tests:
       - |
         fixtures/calculator.rb:4:in `<main>': undefined method `to-the-power-of' for 3:Integer (NoMethodError)
       - |
-        fixtures/calculator.rb:4:in `<main>': undefined method `to-the-power-of' for an instance of Integer (NoMethodError)
-        
+        fixtures/calculator.rb:4:in `<main>': undefined method `to-the-power-of' for 3:Integer (NoMethodError)
+
         puts tokens[0].to_i.send(tokens[1].to_sym, tokens[2].to_i)
+                           ^^^^^
+      - |
+        fixtures/calculator.rb:4:in `<main>': undefined method `to-the-power-of' for an instance of Integer (NoMethodError)
+
+        puts tokens[0].to_i.send(tokens[1].to_sym, tokens[2].to_i)
+                           ^^^^^
+      - |
+        fixtures/calculator.rb:4:in `<main>': undefined method `to-the-power-of' for an instance of Integer (NoMethodError)
+
+        puts tokens[0].to_i.send(tokens[1].to_sym, tokens[2].to_i)
+
                            ^^^^^
 
   - name: ignored-test


### PR DESCRIPTION
GitHub Actions runners for Ubuntu 20.04 seem to have disappeared.

This also:

- updates the `haskell-actions/setup` action
- fixes the Nix verification step so it runs within the Nix shell
- updates one test to handle yet more variations on Ruby's error message structure